### PR TITLE
Convert pindel to use the HTSlib API instead of the legacy samtools API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,21 @@ clean:
 
 Makefile.local:
 	@echo '# Local configuration' > $@
-	@echo '# Location of SAMTools' >> $@
-	@echo "SAMTOOLS=$(realpath $(SAMTOOLS))" >> $@
+	@echo '# Location of HTSlib' >> $@
+	@if [ -z "$(HTSLIB)" ]; then \
+	     echo "HTSLIB_CPPFLAGS=" >> $@; \
+	 elif [ -d $(HTSLIB)/include ]; then \
+	     echo "HTSLIB_CPPFLAGS=-I$(realpath $(HTSLIB)/include)" >> $@; \
+	 else \
+	     echo "HTSLIB_CPPFLAGS=-I$(realpath $(HTSLIB))" >> $@; \
+	 fi
+	@if [ -z "$(HTSLIB)" ]; then \
+	     echo "HTSLIB_LDFLAGS=" >> $@; \
+	 elif [ -d $(HTSLIB)/lib ]; then \
+	     echo "HTSLIB_LDFLAGS=-L$(realpath $(HTSLIB)/lib)" >> $@; \
+	 else \
+	     echo "HTSLIB_LDFLAGS=-L$(realpath $(HTSLIB))" >> $@; \
+	 fi
 	@echo '' >> $@
 	@echo '# Number of threads for functional tests, set to 2 or more, recommended to match number of cores' >> $@
 	@(if [ -e /proc/cpuinfo ] ; then THREADS=`fgrep -c processor /proc/cpuinfo` ; echo "THREADS=${THREADS}" ; else echo 'THREADS=2' ; fi) >> $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,14 +27,14 @@ test:	pindel $(addprefix cppcheck-result-,$(SOURCES:.cpp=.xml))
 # Debug version of pindel
 pindel-debug: $(SOURCES:.cpp=-debug.o)
 	$(CXX) $(LDFLAGS) $^ -fopenmp -g -pg -fprofile-arcs -ftest-coverage \
-	  -lm -lz -L$(SAMTOOLS) -lbam -o $@
+	  $(HTSLIB_LDFLAGS) -lhts -lm -lz -o $@
 #	$(CXX) $(LDFLAGS) $^ -fopenmp -g -pg -fprofile-arcs -ftest-coverage \
-#	-static-libgcc -Bstatic -static -lm -lz -L$(SAMTOOLS) -lbam -o $@
+#	-static-libgcc -Bstatic -static $(HTSLIB_LDFLAGS) -lhts -lm -lz -o $@
 
 # Normal version of pindel	
 pindel:	$(SOURCES:.cpp=.o)
-	$(CXX) $(LDFLAGS) $^ -O3 -fopenmp -lm -lz -L$(SAMTOOLS) -lbam -o $@
-#	$(CXX) $(LDFLAGS) $^ -O3 -fopenmp -Bstatic -static-libgcc -static  -lm -lz -L$(SAMTOOLS) -lbam -o $@
+	$(CXX) $(LDFLAGS) $(HTSLIB_LDFLAGS) $^ -O3 -fopenmp -lhts -lm -lz -o $@
+#	$(CXX) $(LDFLAGS) $(HTSLIB_LDFLAGS) $^ -O3 -fopenmp -Bstatic -static-libgcc -static  -lhts -lm -lz -o $@
 	$(CXX) -O3 SAM_2_PINDEL_cin_2011Sept26.cpp -o sam2pindel
 	$(CXX) -O3 vcfcreator.cpp -o pindel2vcf
 
@@ -44,31 +44,31 @@ clean:
 
 # Pattern rule to create normal .o files	
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -Wall -g -c -O3 -fopenmp -I$(SAMTOOLS) $< -o $@
-#	$(CXX) $(CXXFLAGS) -Wall -g -c -O3 -Bstatic -static-libgcc -static -fopenmp -I$(SAMTOOLS) $< -o $@
+	$(CXX) $(CXXFLAGS) $(HTSLIB_CPPFLAGS) -Wall -g -c -O3 -fopenmp $< -o $@
+#	$(CXX) $(CXXFLAGS) $(HTSLIB_CPPFLAGS) -Wall -g -c -O3 -Bstatic -static-libgcc -static -fopenmp $< -o $@
 
 # Pattern rule to create debug version of .o files
 %-debug.o: %.cpp
 	$(CXX) $(CXXFLAGS) -Wall -g -c -fopenmp -g -pg \
-	  -fprofile-arcs -ftest-coverage -I$(SAMTOOLS) $< -o $@
+	  -fprofile-arcs -ftest-coverage $(HTSLIB_CPPFLAGS) $< -o $@
 #	$(CXX) $(CXXFLAGS) -Wall -Bstatic -static-libgcc -static -g -c -fopenmp -g -pg \
-	  -fprofile-arcs -ftest-coverage -I$(SAMTOOLS) $< -o $@
+	  -fprofile-arcs -ftest-coverage $(HTSLIB_CPPFLAGS) $< -o $@
 
 # Pattern rule to create cppcheck files	
 cppcheck-result-%.xml: %.cpp
-	cppcheck --quiet --enable=all --xml -I$(SAMTOOLS) $(realpath $<) 2> $@
+	cppcheck --quiet --enable=all --xml $(HTSLIB_CPPFLAGS) $(realpath $<) 2> $@
 
 # Pattern rule to create the .d dependency files
 %.d: %.cpp
 	@set -e; rm -f $@; \
-	    $(CXX) -I$(SAMTOOLS) -MM $(CPPFLAGS) $< > $@.$$$$; \
+	    $(CXX) -MM $(CPPFLAGS) $(HTSLIB_CPPFLAGS) $< > $@.$$$$; \
 	    sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 	    $(RM) $@.$$$$
 
 # Pattern rule to create the .d dependency files for the debug version
 %-debug.d: %.cpp
 	@set -e; rm -f $@; \
-	    $(CXX) -I$(SAMTOOLS) -MM $(CPPFLAGS) $< > $@.$$$$; \
+	    $(CXX) -MM $(CPPFLAGS) $(HTSLIB_CPPFLAGS) $< > $@.$$$$; \
 	    sed 's,\($*\)\.o[ :]*,\1-debug.o $@ : ,g' < $@.$$$$ > $@; \
 	    $(RM) $@.$$$$
 	

--- a/src/bam2depth.cpp
+++ b/src/bam2depth.cpp
@@ -8,15 +8,16 @@
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
-#include "bam.h"
+#include "htslib/sam.h"
 #include "bam2depth.h"
 #include "genotyping.h"
 
 
 
 typedef struct {     // auxiliary data structure
-	bamFile fp;      // the file handler
-	bam_iter_t iter; // NULL if a region not specified
+	samFile* fp;     // the file handler
+	bam_hdr_t *hdr;  // the file headers
+	hts_itr_t* iter; // NULL if a region not specified
 	int min_mapQ;    // mapQ filter
 } aux_t;
 
@@ -26,19 +27,9 @@ std::string Spaces(double input);
 static int read_bam(void *data, bam1_t *b) // read level filters better go here to avoid pileup
 {
 	aux_t *aux = (aux_t*)data; // data in fact is a pointer to an auxiliary structure
-	int ret = aux->iter? bam_iter_read(aux->fp, aux->iter, b) : bam_read1(aux->fp, b);
+	int ret = aux->iter? sam_itr_next(aux->fp, aux->iter, b) : sam_read1(aux->fp, aux->hdr, b);
 	if ((int)b->core.qual < aux->min_mapQ) b->core.flag |= BAM_FUNMAP;
 	return ret;
-}
-
-int getChromosomeID( bam_header_t *bamHeaderPtr, const std::string & chromosomeName, const int startPos, const int endPos )
-{
-    int dummyBegin, dummyEnd;
-    int chromosomeID;
-    std::stringstream region;
-    region << chromosomeName << ":" << startPos << "-" << endPos;
-    bam_parse_region(bamHeaderPtr, region.str().c_str(), &chromosomeID, &dummyBegin, &dummyEnd);
-    return chromosomeID;
 }
 
 int bam2depth(const std::string& chromosomeName, const int startPos, const int endPos, const int minBaseQuality, const int minMappingQuality, const std::vector <std::string> & listOfFiles,
@@ -49,7 +40,6 @@ int bam2depth(const std::string& chromosomeName, const int startPos, const int e
 	const bam_pileup1_t **plp;
 	char *reg = 0; // specified region
 	//void *bed = 0; // BED data structure
-	bam_header_t *h = 0; // BAM header of the 1st input
 	aux_t **data;
 	bam_mplp_t mplp;
 
@@ -60,20 +50,15 @@ int bam2depth(const std::string& chromosomeName, const int startPos, const int e
 	beg = startPos;
 	end = endPos;
 	for (i = 0; i < n; ++i) {
-		bam_header_t *htmp;
 		data[i] = (aux_t*)calloc(1, sizeof(aux_t));
-		data[i]->fp = bam_open(listOfFiles[i].c_str(), "r"); // open BAM
+		data[i]->fp = sam_open(listOfFiles[i].c_str(), "r"); // open BAM
 		data[i]->min_mapQ = mapQ;                    // set the mapQ filter
-		htmp = bam_header_read(data[i]->fp);         // read the BAM header
-		if (i == 0) {
-			h = htmp; // keep the header of the 1st BAM
-			//if (reg) bam_parse_region(h, reg, &tid, &beg, &end); // also parse the region
-			tid = getChromosomeID( h, chromosomeName, startPos, endPos );
-		} else bam_header_destroy(htmp); // if not the 1st BAM, trash the header
+		data[i]->hdr = sam_hdr_read(data[i]->fp);    // read the BAM header
+		tid = bam_name2id(data[i]->hdr, chromosomeName.c_str());
 		if (tid >= 0) { // if a region is specified and parsed successfully
-			bam_index_t *idx = bam_index_load(listOfFiles[i].c_str());  // load the index
-			data[i]->iter = bam_iter_query(idx, tid, beg, end); // set the iterator
-			bam_index_destroy(idx); // the index is not needed any more; phase out of the memory
+			hts_idx_t *idx = sam_index_load(data[i]->fp, listOfFiles[i].c_str());  // load the index
+			data[i]->iter = sam_itr_queryi(idx, tid, beg, end); // set the iterator
+			hts_idx_destroy(idx); // the index is not needed any more; phase out of the memory
 		}
 	}
 
@@ -89,7 +74,7 @@ int bam2depth(const std::string& chromosomeName, const int startPos, const int e
 			for (j = 0; j < n_plp[i]; ++j) {
 				const bam_pileup1_t *p = plp[i] + j; // DON'T modfity plp[][] unless you really know
 				if (p->is_del || p->is_refskip) ++m; // having dels or refskips at tid:pos
-				else if (bam1_qual(p->b)[p->qpos] < baseQ) ++m; // low base quality
+				else if (bam_get_qual(p->b)[p->qpos] < baseQ) ++m; // low base quality
 			}
 			sumOfReadDepths[ i ] += n_plp[i] - m;
 		}
@@ -101,10 +86,10 @@ int bam2depth(const std::string& chromosomeName, const int startPos, const int e
 	free(n_plp); free(plp);
 	bam_mplp_destroy(mplp);
 
-	bam_header_destroy(h);
 	for (i = 0; i < n; ++i) {
-		bam_close(data[i]->fp);
-		if (data[i]->iter) bam_iter_destroy(data[i]->iter);
+		bam_hdr_destroy(data[i]->hdr);
+		sam_close(data[i]->fp);
+		if (data[i]->iter) hts_itr_destroy(data[i]->iter);
 		free(data[i]);
 	}
 	free(data); free(reg);

--- a/src/bam2depth.h
+++ b/src/bam2depth.h
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <vector>
-#include "bam.h"
 #include "control_state.h"
 #include "genotyping.h"
 

--- a/src/gz_line_reader.h
+++ b/src/gz_line_reader.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <sstream>
+#include <zlib.h>
 #include "line_reader.h"
 
 

--- a/src/pindel.h
+++ b/src/pindel.h
@@ -30,9 +30,9 @@
 #include <set>
 #include <map>
 
-// Samtools header files
-#include "khash.h"
-#include "sam.h"
+// HTSlib header files
+#include "htslib/khash.h"
+#include "htslib/sam.h"
 
 #include "user_defined_settings.h"
 //#include "bddata.h"
@@ -452,14 +452,6 @@ void ReadInOneChr(std::ifstream & inf_Seq, std::string & TheInput, const std::st
 void parse_flags_and_tags(const bam1_t * b, flags_hit * flags);
 int32_t bam_cigar2len(const bam1_core_t * c, const uint32_t * cigar);
 void build_record(const bam1_t * mapped_read, const bam1_t * unmapped_read, void *data);
-
-#ifdef __cplusplus
-extern "C" {
-int32_t bam_get_tid(const bam_header_t * header, const char *seq_name);
-int32_t bam_aux2i(const uint8_t * s);
-void bam_init_header_hash(bam_header_t * header);
-}
-#endif
 
 std::vector<std::string>
 ReverseComplement(const std::vector<std::string> &input);

--- a/src/search_MEI.cpp
+++ b/src/search_MEI.cpp
@@ -52,7 +52,7 @@ bool is_concordant(const bam1_t* read, unsigned int insert_size) {
         // Reads mapping to different chromosomes.
         return false;
     }
-    if (bam1_strand(read) == bam1_mstrand(read)) {
+    if (bam_is_rev(read) == bam_is_mrev(read)) {
         // Reads mapping to the same strand.
         return false;
     }
@@ -671,11 +671,7 @@ bool comp_breakpoint_pos(const MEI_breakpoint& bp1, const MEI_breakpoint& bp2) {
 // Return code for not being able to open a BAM file.
 const int ERROR_OPENING_ALIGNMENT_FILE = 100;
 
-static int fetch_disc_read_callback(const bam1_t* alignment, void* data) {
-    //    MEI_data* mei_data = static_cast<MEI_data*>(data);
-    std::pair<MEI_data*, UserDefinedSettings*>* env = static_cast<std::pair<MEI_data*, UserDefinedSettings*>*>(data);
-    MEI_data* mei_data = env->first;
-    UserDefinedSettings* userSettings = env->second;
+static int fetch_disc_read_callback(const bam1_t* alignment, MEI_data* mei_data, UserDefinedSettings* userSettings) {
     if (!(alignment->core.flag & BAM_FUNMAP || alignment->core.flag & BAM_FMUNMAP) && // Both ends are mapped.
         !is_concordant(alignment, mei_data->current_insert_size) &&                   // Ends map discordantly.
         // Extra check for (very) large mapping distance.  This is done beside the check for read
@@ -684,16 +680,16 @@ static int fetch_disc_read_callback(const bam1_t* alignment, void* data) {
          abs(alignment->core.pos - alignment->core.mpos) > userSettings->MIN_DD_MAP_DISTANCE)) {
             
             // Save alignment as simple_read object.
-            std::string read_name = enrich_read_name(bam1_qname(alignment), alignment->core.flag & BAM_FREAD1);
-            char strand = bam1_strand(alignment)? Minus : Plus;
-            char mate_strand = bam1_mstrand(alignment)? Minus : Plus;
+            std::string read_name = enrich_read_name(bam_get_qname(alignment), alignment->core.flag & BAM_FREAD1);
+            char strand = bam_is_rev(alignment)? Minus : Plus;
+            char mate_strand = bam_is_mrev(alignment)? Minus : Plus;
             std::string read_group;
             get_read_group(alignment, read_group);
             std::string sample_name;
             get_sample_name(read_group, mei_data->sample_names, sample_name);
             
             simple_read* read = new simple_read(read_name, alignment->core.tid, alignment->core.pos, strand, sample_name,
-                                                get_sequence(bam1_seq(alignment), alignment->core.l_qseq),
+                                                get_sequence(bam_get_seq(alignment), alignment->core.l_qseq),
                                                 alignment->core.mtid, alignment->core.mpos, mate_strand);
             mei_data->discordant_reads.push_back(read);
         }
@@ -711,8 +707,8 @@ static int load_discordant_reads(MEI_data& mei_data, std::vector<bam_info>& bam_
         LOG_DEBUG(*logStream << time_log() << "Loading discordant reads from " << source.BamFile << std::endl);
         
         // Setup link to bamfile, its index and header.
-        bamFile fp = bam_open(source.BamFile.c_str(), "r");
-        bam_index_t *idx = bam_index_load(source.BamFile.c_str());
+        samFile* fp = sam_open(source.BamFile.c_str(), "r");
+        hts_idx_t *idx = sam_index_load(fp, source.BamFile.c_str());
         
         if (idx == NULL) {
             LOG_WARN(*logStream << time_log() << "Failed to load index for " << source.BamFile.c_str() << std::endl);
@@ -721,9 +717,8 @@ static int load_discordant_reads(MEI_data& mei_data, std::vector<bam_info>& bam_
             continue;
         }
         
-        bam_header_t *header = bam_header_read(fp);
-        bam_init_header_hash(header);
-        int tid = bam_get_tid(header, chr_name.c_str());
+        bam_hdr_t *header = sam_hdr_read(fp);
+        int tid = bam_name2id(header, chr_name.c_str());
         
         if (tid < 0) {
             LOG_WARN(*logStream << time_log() << "Could not find sequence in alignment file: '" << chr_name <<
@@ -741,12 +736,14 @@ static int load_discordant_reads(MEI_data& mei_data, std::vector<bam_info>& bam_
         mei_data.current_insert_size = source.InsertSize;
         mei_data.current_chr_name = chr_name;
         
-        // Set up environment variable for callback function.
-        std::pair<MEI_data*, UserDefinedSettings*> env = std::make_pair(&mei_data, userSettings);
-        
         // Load discordant reads into mei_data.
-        bam_fetch(fp, idx, tid, window.getStart(), window.getEnd(), &env, fetch_disc_read_callback);
-        bam_index_destroy(idx);
+        hts_itr_t *iter = sam_itr_queryi(idx, tid, window.getStart(), window.getEnd());
+        bam1_t *b = bam_init1();
+        while (sam_itr_next(fp, iter, b) >= 0)
+                fetch_disc_read_callback(b, &mei_data, userSettings);
+        bam_destroy1(b);
+        hts_itr_destroy(iter);
+        hts_idx_destroy(idx);
     }
     return 0;
 }
@@ -930,9 +927,8 @@ std::map<int, std::string> get_sequence_name_dictionary(ControlState& state) {
     std::map<int, std::string> dict;
     std::vector<bam_info>::iterator bam_info_iter;
     for (bam_info_iter = state.bams_to_parse.begin(); bam_info_iter != state.bams_to_parse.end(); ++bam_info_iter) {
-        bamFile fp = bam_open((*bam_info_iter).BamFile.c_str(), "r");
-        bam_header_t *header = bam_header_read(fp);
-        bam_init_header_hash(header);
+        samFile* fp = sam_open((*bam_info_iter).BamFile.c_str(), "r");
+        bam_hdr_t *header = sam_hdr_read(fp);
         for (int tid = 0; tid < header->n_targets; tid++) {
             dict.insert(std::make_pair(tid, header->target_name[tid]));
         }

--- a/src/search_MEI.h
+++ b/src/search_MEI.h
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-#include "sam.h"
+#include "htslib/sam.h"
 
 // Forward declarations.
 class ControlState;

--- a/src/search_MEI_util.cpp
+++ b/src/search_MEI_util.cpp
@@ -105,7 +105,7 @@ std::string get_sequence(uint8_t* sam_seq, int sam_seq_len) {
     std::string sequence;
     for (int i = 0; i < sam_seq_len; ++i) {
         // Append base letter.
-        sequence.append(1, bam_nt16_rev_table[bam1_seqi(sam_seq, i)]);
+        sequence.append(1, seq_nt16_str[bam_seqi(sam_seq, i)]);
     }
     return sequence;
 }
@@ -338,7 +338,7 @@ bool contains_subseq_any_strand(const std::string& query, const std::string& db,
 
 
 // Set up map linking read group ids with sample names.
-std::map<std::string, std::string> get_sample_dictionary(bam_header_t* header) {
+std::map<std::string, std::string> get_sample_dictionary(bam_hdr_t* header) {
     std::map<std::string, std::string> sample_dict;
     int num_ids;
     int num_names;

--- a/src/search_MEI_util.cpp
+++ b/src/search_MEI_util.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "search_MEI_util.h"
-#include "sam_header.h"
 
 // Logging libraries.
 #include "logdef.h"
@@ -340,33 +339,24 @@ bool contains_subseq_any_strand(const std::string& query, const std::string& db,
 // Set up map linking read group ids with sample names.
 std::map<std::string, std::string> get_sample_dictionary(bam_hdr_t* header) {
     std::map<std::string, std::string> sample_dict;
-    int num_ids;
-    int num_names;
-    char** tmp_ids;
-    if (header->dict == 0) header->dict = sam_header_parse2(header->text);
-    // Convert string literals to char* to feed into samtools api.
-    char* rg_tag = new char[3];
-    strncpy(rg_tag, "RG", 2); 
-    rg_tag[2] = '\0';
-    char* id_tag = new char[3];
-    strncpy(id_tag, "ID", 2);
-    id_tag[2] = '\0';
-    char* sm_tag = new char[3];
-    strncpy(sm_tag, "SM", 2);
-    id_tag[2] = '\0';
-    tmp_ids = sam_header2list(header->dict, rg_tag, id_tag, &num_ids);
-    char** tmp_names;
-    tmp_names = sam_header2list(header->dict, rg_tag, sm_tag, &num_names);
-    if (num_ids > 0 && num_ids == num_names) {
-        for (int i = 0; i < num_ids; i++) {
-            sample_dict.insert(std::make_pair(tmp_ids[i], tmp_names[i]));
+
+    std::istringstream header_stream(header->text);
+    std::string line;
+    while (getline(header_stream, line)) {
+        if (line.compare(0, 3, "@RG") == 0) {
+            size_t idpos = line.find("\tID:");
+            size_t smpos = line.find("\tSM:");
+            if (idpos != std::string::npos && smpos != std::string::npos) {
+                idpos += 4;
+                smpos += 4;
+                line += '\t';
+                std::string id(line, idpos, line.find('\t', idpos) - idpos);
+                std::string sm(line, smpos, line.find('\t', smpos) - smpos);
+                sample_dict.insert(std::make_pair(id, sm));
+            }
         }
     }
-    free(tmp_ids);
-    free(tmp_names);
-    delete rg_tag;
-    delete id_tag;
-    delete sm_tag;
+
     return sample_dict;
 }
 

--- a/src/search_MEI_util.h
+++ b/src/search_MEI_util.h
@@ -60,7 +60,7 @@ bool contains_subseq(const std::string& query, const std::string& db, int min_le
 bool contains_subseq_any_strand(const std::string& query, const std::string& db, int min_score=12);
 
 // Construct a mapping from read group ID to sample name given a BAM header.
-std::map<std::string, std::string> get_sample_dictionary(bam_header_t* header);
+std::map<std::string, std::string> get_sample_dictionary(bam_hdr_t* header);
 
 void get_sample_name(std::string& read_group, std::map<std::string, std::string>& sample_dictionary, 
                      std::string& sample_name);


### PR DESCRIPTION
This pull request converts the pindel source code to use HTSlib for its BAM-reading needs rather than the old samtools 0.1.x API.  Since the old API is unmaintained (and has been for several years), I would suggest converting wholesale as in this PR rather than complicating the code by retaining the option to use either old-samtools or htslib.

Using the currently-maintained API will fix bugs such as #9; using the better-packaged htslib will fix issues #3 and #10 and remove the need for such as #11.

This now compiles, but I have not tested it.

Still to do:
- [x] Fix header parsing in `search_MEI_util.cpp`
- [x] Update makefiles to look for htslib instead of old samtools

Eventually README.md and INSTALL will need to be updated to talk about HTSlib instead of Samtools too.