### PR TITLE
Fix to allow compilation on Debian 9.0

### DIFF
--- a/src/bddata.cpp
+++ b/src/bddata.cpp
@@ -119,7 +119,7 @@ void BDData::loadBDFile(const std::string& filename)
 
          firstPos += g_SpacerBeforeAfter; // ??? ask Kai
          secondPos += g_SpacerBeforeAfter;
-         if (firstChrName == secondChrName && secondChrName != "" && abs(firstPos - secondPos) < 500) {
+         if (firstChrName == secondChrName && secondChrName != "" && abs(static_cast<int>(firstPos - secondPos)) < 500) {
             continue;
          }
          if ( firstChrName!="" && secondChrName!="") {
@@ -180,16 +180,16 @@ void SortRPByChrPos(std::vector <RP_READ> & Reads_RP) { // no interchromosome RP
 bool RecipicalOverlap(RP_READ & first, RP_READ & second)
 {
    int distance = 1000;
-   if (abs(first.PosA - first.PosA1) > distance) {
+   if (abs(static_cast<int>(first.PosA - first.PosA1)) > distance) {
       return false;
    }
-   if (abs(first.PosB - first.PosB1) > distance) {
+   if (abs(static_cast<int>(first.PosB - first.PosB1)) > distance) {
       return false;
    }
-   if (abs(second.PosA - second.PosA1) > distance) {
+   if (abs(static_cast<int>(second.PosA - second.PosA1)) > distance) {
       return false;
    }
-   if (abs(second.PosB - second.PosB1) > distance) {
+   if (abs(static_cast<int>(second.PosB - second.PosB1)) > distance) {
       return false;
    }
    float cutoff = 0.9;
@@ -424,7 +424,7 @@ void ModifyRP(std::vector <RP_READ> & Reads_RP)
          Reads_RP[first].PosB = Reads_RP[first].PosB + Reads_RP[first].ReadLength;
          Reads_RP[first].PosB1 = Reads_RP[first].PosB1 + Reads_RP[first].ReadLength;
       }
-      if (Reads_RP[first].ChrNameA == Reads_RP[first].ChrNameB && abs(Reads_RP[first].PosA - Reads_RP[first].PosB) < 500) {
+      if (Reads_RP[first].ChrNameA == Reads_RP[first].ChrNameB && abs(static_cast<int>(Reads_RP[first].PosA - Reads_RP[first].PosB)) < 500) {
          Reads_RP[first].Visited = true;
       }
       //std::cout << "Final: " << Reads_RP[first].ChrNameA << " " << Reads_RP[first].DA << " " << Reads_RP[first].PosA << "\t" << Reads_RP[first].ChrNameB << " " << Reads_RP[first].DB << " " << Reads_RP[first].PosB << std::endl;


### PR DESCRIPTION
When compiling with gcc on Debian 9.0, bddata.cpp fails due to ambiguous calls to `abs(unsigned int)`. This PR explicitly casts the argument of the relevant `abs()` calls to fix this.