### PR TITLE
Support for krand in htslib 1.6

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -30,6 +30,7 @@
 #include "htslib/kstring.h"
 #include "htslib/kseq.h"
 #include "htslib/khash.h"
+#define hts_drand48(void) drand48() //HTSLIB 1.6 compatibility
 #include "htslib/ksort.h"
 
 // Pindel header files


### PR DESCRIPTION
htslib 1.6 changed how ksort is exposed, internalizing drand48 into
hts_drand48 (samtools/htslib#559). This caused a lookup error during
compiling:
```
src/reader.cpp:67: undefined reference to `hts_drand48()'
```
Triggered when initializing ksort:

https://github.com/chapmanb/pindel/blob/b706fba61c64a11fb1d3716d501fd2f4d8992e29/src/reader.cpp#L67

This works around the issue by referencing hts_drand48 to drand48.

I'm not sure if this is the best long term fix but hopefully will be a workaround for folks or lead to discussion of a better approach to take.