### PR TITLE
Change InsertSize type from short to int for large sequences

### DIFF
--- a/src/pindel.h
+++ b/src/pindel.h
@@ -315,7 +315,7 @@ struct SPLIT_READ {
    char MatchedFarD;
    unsigned int MatchedRelPos;
    short MS; // rename MappingQuality ?
-   short InsertSize;
+   int InsertSize;
    std::string Tag; // rename SampleName ?
    std::map <std::string, unsigned> SampleName2Number;
    unsigned Thickness;


### PR DESCRIPTION
I discovered an overflow when running pindel, the solution is to change types. 