### PR TITLE
allow float insert size in config file without losing sample name ( issue 81 )

### DIFF
--- a/src/pindel.cpp
+++ b/src/pindel.cpp
@@ -29,6 +29,7 @@
 #include <set>
 #include <map>
 #include <sstream>
+#include <cstdlib>
 
 // Pindel header files
 #include "logstream.h"
@@ -659,14 +660,16 @@ std::string convertToXBaiFilename( const std::string& bamFileName )
 void readBamConfigFile(std::string& bamConfigFilename, ControlState& currentState )
 {
    int sampleCounter=0;
+   std::string tempInsertSize;
    std::ifstream BamConfigFile( bamConfigFilename.c_str() );
    if (BamConfigFile) {
       while (BamConfigFile.good()) {
          bam_info tempBamInfo;
-         BamConfigFile >> tempBamInfo.BamFile >> tempBamInfo.InsertSize;
+         BamConfigFile >> tempBamInfo.BamFile >> tempInsertSize;
          if (!BamConfigFile.good()) {
             break;
          }
+         tempBamInfo.InsertSize = strtol( tempInsertSize.c_str(), NULL, 10 );
          tempBamInfo.Tag = "";
          BamConfigFile >> tempBamInfo.Tag;
          if (tempBamInfo.Tag=="") {


### PR DESCRIPTION
a float in the average insert size field of the config file overwrites sample name.

https://github.com/genome/pindel/issues/81