### PR TITLE
typecast abs() to long int to resolve ambiguity in g++ 7.3.0

### DIFF
--- a/src/bddata.cpp
+++ b/src/bddata.cpp
@@ -119,7 +119,7 @@ void BDData::loadBDFile(const std::string& filename)
 
          firstPos += g_SpacerBeforeAfter; // ??? ask Kai
          secondPos += g_SpacerBeforeAfter;
-         if (firstChrName == secondChrName && secondChrName != "" && abs(firstPos - secondPos) < 500) {
+         if (firstChrName == secondChrName && secondChrName != "" && abs((long int)(firstPos - secondPos)) < 500) {
             continue;
          }
          if ( firstChrName!="" && secondChrName!="") {
@@ -180,16 +180,16 @@ void SortRPByChrPos(std::vector <RP_READ> & Reads_RP) { // no interchromosome RP
 bool RecipicalOverlap(RP_READ & first, RP_READ & second)
 {
    int distance = 1000;
-   if (abs(first.PosA - first.PosA1) > distance) {
+   if (abs((long int)(first.PosA - first.PosA1)) > distance) {
       return false;
    }
-   if (abs(first.PosB - first.PosB1) > distance) {
+   if (abs((long int)(first.PosB - first.PosB1)) > distance) {
       return false;
    }
-   if (abs(second.PosA - second.PosA1) > distance) {
+   if (abs((long int)(second.PosA - second.PosA1)) > distance) {
       return false;
    }
-   if (abs(second.PosB - second.PosB1) > distance) {
+   if (abs((long int)(second.PosB - second.PosB1)) > distance) {
       return false;
    }
    float cutoff = 0.9;
@@ -424,7 +424,7 @@ void ModifyRP(std::vector <RP_READ> & Reads_RP)
          Reads_RP[first].PosB = Reads_RP[first].PosB + Reads_RP[first].ReadLength;
          Reads_RP[first].PosB1 = Reads_RP[first].PosB1 + Reads_RP[first].ReadLength;
       }
-      if (Reads_RP[first].ChrNameA == Reads_RP[first].ChrNameB && abs(Reads_RP[first].PosA - Reads_RP[first].PosB) < 500) {
+      if (Reads_RP[first].ChrNameA == Reads_RP[first].ChrNameB && abs((long int)(Reads_RP[first].PosA - Reads_RP[first].PosB)) < 500) {
          Reads_RP[first].Visited = true;
       }
       //std::cout << "Final: " << Reads_RP[first].ChrNameA << " " << Reads_RP[first].DA << " " << Reads_RP[first].PosA << "\t" << Reads_RP[first].ChrNameB << " " << Reads_RP[first].DB << " " << Reads_RP[first].PosB << std::endl;

--- a/src/genotyping.cpp
+++ b/src/genotyping.cpp
@@ -124,7 +124,7 @@ void doGenotyping (ControlState & CurrentState, UserDefinedSettings* userSetting
    // step 4 for each variant, do genotyping
    for (unsigned SV_index =0; SV_index < AllSV4Genotyping.size(); SV_index++) {
       // step 4.1 if type == DEL, GenotypeDel
-      if (AllSV4Genotyping[SV_index].ChrA == AllSV4Genotyping[SV_index].ChrB && abs(AllSV4Genotyping[SV_index].PosA - AllSV4Genotyping[SV_index].PosB) < SV_Genotype_Cutoff) {
+      if (AllSV4Genotyping[SV_index].ChrA == AllSV4Genotyping[SV_index].ChrB && abs((long int)(AllSV4Genotyping[SV_index].PosA - AllSV4Genotyping[SV_index].PosB)) < SV_Genotype_Cutoff) {
          std::cout << "Skip One SV " << OneSV.Type << " " << OneSV.ChrA << " " << OneSV.PosA << " "
                    << OneSV.CI_A << " " << OneSV.ChrB << " " << OneSV.PosB << " "
                    << OneSV.CI_B << std::endl;

--- a/src/pindel.cpp
+++ b/src/pindel.cpp
@@ -1554,7 +1554,7 @@ void MergeInterChr(ControlState& currentState, UserDefinedSettings *usersettings
             continue;
          }
          if (All[index_a].FirstChrName == All[index_b].FirstChrName && All[index_a].SecondChrName == All[index_b].SecondChrName) {
-            if (abs(All[index_a].FirstPos - All[index_b].FirstPos) < 10 && abs(All[index_a].SecondPos - All[index_b].SecondPos) < 10 && All[index_a].NumSupport + All[index_b].NumSupport >= cutoff) {
+            if (abs((long int)(All[index_a].FirstPos - All[index_b].FirstPos)) < 10 && abs((long int)(All[index_a].SecondPos - All[index_b].SecondPos)) < 10 && All[index_a].NumSupport + All[index_b].NumSupport >= cutoff) {
 
                INToutputfile << "chr\t" << All[index_a].FirstChrName << "\tpos\t" << unsigned((All[index_a].FirstPos + All[index_b].FirstPos) / 2) << "\tchr\t" << All[index_a].SecondChrName << "\tpos\t"
                              << unsigned((All[index_a].SecondPos + All[index_b].SecondPos) / 2) << "\tseq\t" << All[index_a].InsertedSequence << "\tsupport\t" << All[index_a].NumSupport + All[index_b].NumSupport << "\tINFOR\t"


### PR DESCRIPTION
I couldn't build without this change. Error message below. 
```
bddata.cpp:192:38: error: call of overloaded 'abs(unsigned int)' is ambiguous
    if (abs(second.PosB - second.PosB1) > distance) {
                                      ^
In file included from /usr/include/c++/7/cstdlib:75:0,
                 from /usr/include/c++/7/bits/stl_algo.h:59,
                 from /usr/include/c++/7/algorithm:62,
                 from bddata.cpp:1:
/usr/include/stdlib.h:837:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
```