### PR TITLE
Make dockerfile build with htslib that was current at time of creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/demo/
+/devtools/
+/somatic_filter/
+/test/
+/*.*/
+/tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,35 @@
 FROM ubuntu:xenial
 MAINTAINER = Shin Leong <sleong@wustl.edu>
-RUN apt-get update && apt-get install -y git binutils
-RUN apt-get install -y automake cmake git libncurses5-dev zlib1g-dev g++
+RUN apt-get -yq update \
+&& apt-get install -yq \
+binutils \
+automake \
+cmake \
+libncurses5-dev \
+zlib1g-dev \
+g++ \
+libopenblas-base \
+libopenblas-dev \
+libnss-sss \
+curl \
+bzip2 \
+&& apt-get clean
 
-RUN cd /usr/local/ && git clone --recursive https://github.com/samtools/htslib
-RUN cd /usr/local/htslib && make && make install
-RUN cd /usr/local/ && git clone --recursive https://github.com/genome/pindel.git
+WORKDIR /usr/local/htslib
+RUN curl -sSL https://github.com/samtools/htslib/releases/download/1.3.1/htslib-1.3.1.tar.bz2 | tar --strip-components 1 -xj \
+&& make && make install
 
-RUN apt-get install -y wget libopenblas-base libopenblas-dev
-RUN cd /usr/local/pindel/ && ./INSTALL /usr/local/htslib
-
-RUN apt-get install -y libnss-sss
-
-RUN apt-get clean
+WORKDIR /usr/local/pindel
+COPY . .
+RUN ./INSTALL /usr/local/htslib
 
 RUN ln -s /usr/local/pindel/pindel /usr/local/bin/pindel
 
+## USER CONFIGURATION
+RUN addgroup ubuntu \
+&& adduser --home /home/ubuntu --disabled-password --gecos '' --ingroup ubuntu --shell /bin/bash ubuntu
+
+USER    ubuntu
+WORKDIR /home/ubuntu
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Users need to clone or download repo archive so build is of known versions of code, not the master branch.